### PR TITLE
removing isLoading and isActive from textarea to resolve warning mess…

### DIFF
--- a/src/elements/forms/textarea.js
+++ b/src/elements/forms/textarea.js
@@ -17,7 +17,6 @@ export default class Textarea extends Component {
       'isDanger',
     ]),
     state: PropTypes.oneOf([
-      'isLoading',
       'isDisabled',
     ]),
     help: PropTypes.shape({
@@ -35,8 +34,6 @@ export default class Textarea extends Component {
   static defaultProps = {
     style: {},
     className: '',
-    isLoading: false,
-    isActive: false,
   };
 
   createControlClassName() {


### PR DESCRIPTION
This is a fix for Issue #56 Textarea giving me a warning in React - unknown props: 'isLoading', 'isActive'