### PR TITLE
Remove duplicated font-size from content css

### DIFF
--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -17,7 +17,6 @@
   font-weight: normal;
   vertical-align: baseline;
   background-color: transparent;
-  font-size: 14px;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
The font-size attribute was duplicated on the content element.

(I'm working out how to change my base font size to 16px and in the meanwhile found if I removed the duplication of font-size on the content element I got what I needed.)