### PR TITLE
<span></span> wrapping button content

### DIFF
--- a/src/elements/button.js
+++ b/src/elements/button.js
@@ -102,11 +102,13 @@ export default class Button extends Component {
         style={this.props.style}
         className={this.createClassName()}
       >
+        <span>
         {
           this.props.icon
             ? this.renderIcon()
             : this.props.children
         }
+        </span>
       </button>
     );
   }


### PR DESCRIPTION
I found a problem with centre aligning text in a button on Safari. It's to do with the width being set and Safari (and iPhone) then ignoring the text-align attribute. Putting <span></span> around the button content resolved the problem. (One shortcoming of the solution is that onClick handlers on the button may need to check if the target is the span or the button if they need to deal with the target itself.)