### PR TITLE
Make modal header content accept elements

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -42,7 +42,7 @@ export default class Modal extends Component {
       return (
         <div className={[styles.modalCard, '__re-bulma_modal_card'].join(' ')}>
           <header className={styles.modalCardHead}>
-            <p className={styles.modalCardTitle}>{this.props.headerContent}</p>
+            <div className={styles.modalCardTitle}>{this.props.headerContent}</div>
             <button className={styles.delete} onClick={this.props.onCloseRequest} />
           </header>
           <section className={styles.modalCardBody}>


### PR DESCRIPTION
This change makes the modal header content accept react elements, not only text. I use this because i want to be able to style the content a bit, works good for using <Subtitle> etc.